### PR TITLE
Fixes for latest versions

### DIFF
--- a/harness.py
+++ b/harness.py
@@ -11,6 +11,7 @@ import lox
 from aider.coders import Coder
 from aider.io import InputOutput
 from aider.models import Model, register_litellm_models
+from aider.repo import GitRepo
 
 from dump import dump
 from tests import run_tests
@@ -150,11 +151,13 @@ def get_coder(model, git_dname, chat_history_file, test_cmd, temperature, oracle
     )
 
     dump(git_dname)
+    repo = GitRepo(io,  fnames=None, git_dname=git_dname,models=model.commit_message_models()) 
+
 
     coder = Coder.create(
         main_model=model,
         io=io,
-        git_dname=git_dname,
+        repo=repo,
         map_tokens=2048,  # Use 2k tokens for the repo map
         stream=False,
         auto_commits=False,  # Don't bother git committing changes
@@ -163,7 +166,7 @@ def get_coder(model, git_dname, chat_history_file, test_cmd, temperature, oracle
         test_cmd=test_cmd,
         # verbose=True,
         # edit_format="udiff",
-        max_chat_history_tokens=8*1024,
+        # max_chat_history_tokens=8*1024,
     )
     coder.temperature = temperature
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 lox
 aider-chat
-git+https://github.com/princeton-nlp/SWE-bench
+swebench==1.1.5
 pre-commit


### PR DESCRIPTION
Hi @paul-gauthier, I'm trying to get this to work with the current versions and I faced the same issues in #5 . These are some updates to this repo, but some would need to happen on the Aider side.

This installation pins swebench==1.1.5 because report.py requires `swebench.metrics.report.get_model_report` which was removed from later versions (I'm not clear what they replaced it with).

There is an extra change I had to do to run SWE-Bench Lite that I haven't added here because there might already be a better way to do it. That change is to `report.py`, and it's about importing `LITE_DATASET_FNAME` and substituting it in most places that mention `FULL_DATASET_FNAME`. But there might be a better way to do that or existing functionality. I haven't read the code in detail yet.

On the aider side, what I've had to change was:
1- in repomap.py: in `get_scm_fname` Change `except KeyError` to  `except (KeyError, TypeError)`
2- Also in `repomap.py`:   
change
```python
 if not query_scm.exists(): 
            return
```
to
```python
if query_scm is None or not query_scm.exists(): 
            return
```

Otherwise, it may fail when facing file extensions not in tree-sitter.

Also need to point out this now needs to be run in python 3.11. SWE-bench-docker's `run_evaluations.py` needs `asyncio.TaskGroup`.

So for my setup, I did this before installing the requirements:
```bash
conda create -n aider-swe python=3.11
```